### PR TITLE
feat: auto project creation and codex section

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3,12 +3,14 @@ const startScreen = document.getElementById('start-screen');
 const app = document.getElementById('app');
 const projectList = document.getElementById('project-list');
 const newProjectBtn = document.getElementById('new-project-btn');
-const historyList = document.getElementById('history-list');
 const promptForm = document.getElementById('prompt-form');
 const promptInput = document.getElementById('prompt-input');
 const fileInput = document.getElementById('file-input');
 const messagesDiv = document.getElementById('messages');
 const modelSelect = document.getElementById('model-select');
+const codexInput = document.getElementById('codex-input');
+const codexOutput = document.getElementById('codex-output');
+const codexSubmit = document.getElementById('codex-submit');
 
 let currentProject = null;
 
@@ -35,26 +37,26 @@ projectList.addEventListener('click', e => {
   console.log('Project list clicked', e.target);
   if (e.target.tagName === 'LI') {
     currentProject = e.target.dataset.id;
-    loadHistory();
-  }
-});
-
-historyList.addEventListener('click', async e => {
-  console.log('History list clicked', e.target);
-  if (e.target.tagName === 'LI') {
-    const chatId = e.target.dataset.id;
-    const res = await fetch(`/api/projects/${currentProject}/chats/${chatId}`);
-    const chat = await res.json();
-    renderChat(chat);
+    loadProjectHistory();
   }
 });
 
 promptForm.addEventListener('submit', async e => {
   e.preventDefault();
   console.log('Prompt form submitted');
-  if (!currentProject) return alert('Select a project');
   const prompt = promptInput.value;
   if (!prompt) return;
+  if (!currentProject) {
+    const name = prompt.trim().substring(0, 20) || 'project';
+    const resProj = await fetch('/api/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name })
+    });
+    const proj = await resProj.json();
+    currentProject = proj.id;
+    loadProjects();
+  }
   appendMessage('user', prompt);
   const data = new FormData();
   data.append('prompt', prompt);
@@ -63,7 +65,6 @@ promptForm.addEventListener('submit', async e => {
   const res = await fetch(`/api/projects/${currentProject}/chat`, { method: 'POST', body: data });
   const json = await res.json();
   appendMessage('bot', json.response);
-  addHistoryItem(json);
   promptInput.value = '';
   fileInput.value = '';
 });
@@ -71,7 +72,16 @@ promptForm.addEventListener('submit', async e => {
 function appendMessage(role, text) {
   const div = document.createElement('div');
   div.className = `message ${role}`;
-  div.textContent = text;
+  if (/```/.test(text) || text.includes('\n')) {
+    const codeText = text.replace(/```/g, '');
+    const pre = document.createElement('pre');
+    const code = document.createElement('code');
+    code.textContent = codeText;
+    pre.appendChild(code);
+    div.appendChild(pre);
+  } else {
+    div.textContent = text;
+  }
   messagesDiv.appendChild(div);
   messagesDiv.scrollTop = messagesDiv.scrollHeight;
 }
@@ -88,23 +98,26 @@ async function loadProjects() {
   });
 }
 
-async function loadHistory() {
+async function loadProjectHistory() {
   const res = await fetch(`/api/projects/${currentProject}/chats`);
   const chats = await res.json();
-  historyList.innerHTML = '';
-  chats.forEach(c => addHistoryItem(c));
   messagesDiv.innerHTML = '';
+  for (const c of chats) {
+    const resChat = await fetch(`/api/projects/${currentProject}/chats/${c.id}`);
+    const chat = await resChat.json();
+    appendMessage('user', chat.prompt);
+    appendMessage('bot', chat.response);
+  }
 }
 
-function addHistoryItem(chat) {
-  const li = document.createElement('li');
-  li.textContent = chat.title;
-  li.dataset.id = chat.id;
-  historyList.appendChild(li);
-}
-
-function renderChat(chat) {
-  messagesDiv.innerHTML = '';
-  appendMessage('user', chat.prompt);
-  appendMessage('bot', chat.response);
-}
+codexSubmit.addEventListener('click', async () => {
+  const prompt = codexInput.value;
+  if (!prompt) return;
+  const res = await fetch('/api/codex', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt })
+  });
+  const json = await res.json();
+  codexOutput.textContent = json.response || json.error || '';
+});

--- a/public/index.html
+++ b/public/index.html
@@ -17,10 +17,6 @@
         <ul id="project-list"></ul>
         <button id="new-project-btn">New Project</button>
       </section>
-      <section class="history">
-        <h2>History</h2>
-        <ul id="history-list"></ul>
-      </section>
     </aside>
     <main id="chat">
       <header>
@@ -38,6 +34,12 @@
         <input type="text" id="prompt-input" placeholder="Type your message">
         <button type="submit">Send</button>
       </form>
+      <section id="codex">
+        <h2>Codex</h2>
+        <textarea id="codex-input" placeholder="Enter code prompt"></textarea>
+        <button id="codex-submit">Run</button>
+        <pre id="codex-output"></pre>
+      </section>
     </main>
   </div>
   <script src="app.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -119,3 +119,24 @@ header {
   font-weight: bold;
   cursor: pointer;
 }
+
+pre {
+  background: #000;
+  padding: 0.5rem;
+  overflow-x: auto;
+}
+
+#codex {
+  padding: 1rem;
+  border-top: 1px solid #333;
+}
+
+#codex textarea {
+  width: 100%;
+  height: 100px;
+  margin-bottom: 0.5rem;
+  background: #111;
+  border: 1px solid #333;
+  color: #eee;
+  padding: 0.5rem;
+}

--- a/server.js
+++ b/server.js
@@ -111,5 +111,21 @@ app.post('/api/projects/:projectId/chat', upload.array('files'), async (req, res
   res.json({ ...chatData, id: file });
 });
 
+// Standalone Codex endpoint
+app.post('/api/codex', async (req, res) => {
+  const { prompt } = req.body;
+  if (!prompt) return res.status(400).json({ error: 'prompt required' });
+  try {
+    const completion = await openai.completions.create({
+      model: 'code-davinci-002',
+      prompt,
+      max_tokens: 256
+    });
+    res.json({ response: completion.choices[0].text.trim() });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Server listening on ${PORT}`));


### PR DESCRIPTION
## Summary
- auto-create a project from the first prompt when none selected
- display code snippets in formatted blocks
- add standalone Codex section and API endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adeea4b19c832bac438189e3103858