### PR TITLE
Add D3 login screen, query limits and GitHub codex

### DIFF
--- a/public/chat.js
+++ b/public/chat.js
@@ -7,6 +7,12 @@ const fileInput = document.getElementById('file-input');
 const messagesDiv = document.getElementById('messages');
 const modelSelect = document.getElementById('model-select');
 
+let remainingQueries = parseInt(localStorage.getItem('remainingQueries') || '0');
+const queryLimit = document.createElement('div');
+queryLimit.id = 'query-limit';
+document.querySelector('header .spacer').appendChild(queryLimit);
+updateQueryDisplay();
+
 let currentProject = null;
 
 openCodexBtn.addEventListener('click', () => {
@@ -35,6 +41,10 @@ promptForm.addEventListener('submit', async e => {
   e.preventDefault();
   const prompt = promptInput.value;
   if (!prompt) return;
+  if (remainingQueries <= 0) {
+    alert('Query limit reached');
+    return;
+  }
   if (!currentProject) {
     const name = prompt.trim().substring(0, 20) || 'project';
     const resProj = await fetch('/api/projects', {
@@ -56,6 +66,9 @@ promptForm.addEventListener('submit', async e => {
   appendMessage('bot', json.response);
   promptInput.value = '';
   fileInput.value = '';
+  remainingQueries--;
+  localStorage.setItem('remainingQueries', remainingQueries);
+  updateQueryDisplay();
 });
 
 function appendMessage(role, text) {
@@ -101,3 +114,7 @@ async function loadProjectHistory() {
 }
 
 loadProjects();
+
+function updateQueryDisplay() {
+  queryLimit.textContent = `Queries left: ${remainingQueries}`;
+}

--- a/public/codex.html
+++ b/public/codex.html
@@ -9,6 +9,12 @@
 <body>
   <section id="codex-page">
     <h2>Codex</h2>
+    <div id="github-connect">
+      <input type="text" id="repo-url" placeholder="owner/repo">
+      <input type="password" id="github-token" placeholder="GitHub token (optional)">
+      <button id="load-repo">Load Repo</button>
+      <select id="file-select"></select>
+    </div>
     <textarea id="codex-input" placeholder="Enter code prompt"></textarea>
     <button id="codex-submit">Run</button>
     <pre><code id="codex-output"></code></pre>

--- a/public/codex.js
+++ b/public/codex.js
@@ -1,14 +1,46 @@
 const codexInput = document.getElementById('codex-input');
 const codexOutput = document.getElementById('codex-output');
 const codexSubmit = document.getElementById('codex-submit');
+const repoInput = document.getElementById('repo-url');
+const tokenInput = document.getElementById('github-token');
+const loadRepoBtn = document.getElementById('load-repo');
+const fileSelect = document.getElementById('file-select');
+
+let currentFile = '';
+
+loadRepoBtn.addEventListener('click', async () => {
+  const repo = repoInput.value.trim();
+  if (!repo) return;
+  const headers = tokenInput.value ? { Authorization: `token ${tokenInput.value}` } : {};
+  const res = await fetch(`https://api.github.com/repos/${repo}/contents`, { headers });
+  const files = await res.json();
+  fileSelect.innerHTML = '<option value="">Select file</option>';
+  files.filter(f => f.type === 'file').forEach(f => {
+    const opt = document.createElement('option');
+    opt.value = f.path;
+    opt.textContent = f.path;
+    fileSelect.appendChild(opt);
+  });
+});
+
+fileSelect.addEventListener('change', async () => {
+  const repo = repoInput.value.trim();
+  const path = fileSelect.value;
+  if (!repo || !path) return;
+  const headers = tokenInput.value ? { Authorization: `token ${tokenInput.value}` } : {};
+  const res = await fetch(`https://api.github.com/repos/${repo}/contents/${path}`, { headers });
+  const file = await res.json();
+  currentFile = atob(file.content);
+});
 
 codexSubmit.addEventListener('click', async () => {
   const prompt = codexInput.value;
   if (!prompt) return;
+  const fullPrompt = currentFile ? `${currentFile}\n\n${prompt}` : prompt;
   const res = await fetch('/api/codex', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ prompt })
+    body: JSON.stringify({ prompt: fullPrompt })
   });
   const json = await res.json();
   codexOutput.textContent = json.response || json.error || '';

--- a/public/index.html
+++ b/public/index.html
@@ -4,11 +4,18 @@
   <meta charset="UTF-8">
   <title>Carlton</title>
   <link rel="stylesheet" href="style.css">
+  <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
 <body>
+  <svg id="bg"></svg>
   <div id="landing">
     <h1>Whatcha Wanna Talk About?</h1>
-    <button id="startbtn">Start</button>
+    <div id="login">
+      <input type="text" id="username" placeholder="Username">
+      <input type="password" id="password" placeholder="Password">
+      <button id="loginbtn">Login</button>
+      <button id="guestbtn">Guest Login</button>
+    </div>
   </div>
   <script src="start.js"></script>
 </body>

--- a/public/start.js
+++ b/public/start.js
@@ -1,3 +1,43 @@
-document.getElementById('startbtn').addEventListener('click', () => {
+const svg = d3.select('#bg')
+  .attr('width', window.innerWidth)
+  .attr('height', window.innerHeight);
+
+const nodes = d3.range(30).map(() => ({ r: Math.random() * 10 + 5 }));
+
+const simulation = d3.forceSimulation(nodes)
+  .force('charge', d3.forceManyBody().strength(5))
+  .force('center', d3.forceCenter(window.innerWidth / 2, window.innerHeight / 2))
+  .force('collision', d3.forceCollide().radius(d => d.r + 1))
+  .on('tick', ticked);
+
+const circles = svg.selectAll('circle')
+  .data(nodes)
+  .enter()
+  .append('circle')
+  .attr('r', d => d.r)
+  .attr('fill', 'rgba(255,255,255,0.5)');
+
+function ticked() {
+  circles.attr('cx', d => d.x)
+    .attr('cy', d => d.y);
+}
+
+function login(user) {
+  localStorage.setItem('user', user);
+  localStorage.setItem('remainingQueries', '20');
   window.location.href = 'chat.html';
+}
+
+document.getElementById('loginbtn').addEventListener('click', () => {
+  const u = document.getElementById('username').value;
+  const p = document.getElementById('password').value;
+  if (u === 'admin' && p === 'admin123') {
+    login('admin');
+  } else {
+    alert('Invalid credentials');
+  }
+});
+
+document.getElementById('guestbtn').addEventListener('click', () => {
+  login('guest');
 });

--- a/public/style.css
+++ b/public/style.css
@@ -12,17 +12,26 @@ body {
   justify-content: center;
   align-items: center;
   height: 100vh;
-  background: linear-gradient(135deg, #1e3c72, #2a5298);
   color: #fff;
   text-align: center;
+  background: linear-gradient(135deg, #1e3c72, #2a5298);
 }
 #landing h1 {
   font-size: 3rem;
   margin-bottom: 2rem;
 }
-#startbtn {
-  padding: 1rem 2rem;
-  font-size: 1.25rem;
+#login {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+#login input {
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  border: none;
+}
+#login button {
+  padding: 0.5rem 1rem;
   border: none;
   border-radius: 8px;
   background: #fff;
@@ -30,12 +39,23 @@ body {
   cursor: pointer;
   transition: transform 0.2s;
 }
-#startbtn:hover { transform: scale(1.05); }
+#login button:hover { transform: scale(1.05); }
+
+#bg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+}
 
 /* App layout */
 #app {
   display: flex;
   height: 100vh;
+  border: 4px solid dodgerblue;
+  box-shadow: 0 0 15px rgba(255, 255, 255, 0.4);
 }
 
 #sidebar {
@@ -74,6 +94,7 @@ header {
 }
 header .spacer { flex: 1; }
 #logo { width: 40px; height: 40px; }
+#query-limit { margin-left: 1rem; }
 
 #messages {
   flex: 1;
@@ -119,6 +140,23 @@ pre {
 /* Codex window */
 #codex-page {
   padding: 1rem;
+  background: linear-gradient(135deg, #1e3c72, #2a5298);
+  min-height: 100vh;
+  color: #fff;
+}
+#github-connect {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+#github-connect input,
+#github-connect select {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  color: #f0f6fc;
+  border-radius: 4px;
+  padding: 0.5rem;
 }
 #codex-page textarea {
   width: 100%;


### PR DESCRIPTION
## Summary
- Enhance landing page with D3 animated nodes and login form for admin or guest access
- Limit chat usage to 20 queries per login and display remaining count with styled app border
- Expand Codex page to load GitHub repos and select files for context-aware code assistance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adf4c4540c832baa9bf75b92b6924b