### PR TITLE
style: improve chat UI and code rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Carlton is a simple web-based AI assistant that uses the OpenAI API. It features
 
 The app will be available at `http://localhost:3000`.
 
+## Admin Login
+
+The default admin password is `admin123`.
+
 ## Tests
 
 Run a basic test suite with:

--- a/public/chat.html
+++ b/public/chat.html
@@ -3,10 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>Carlton Chat</title>
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark.min.css">
 </head>
-<body>
+<body class="bg-gray-900 text-white">
   <div id="app">
     <aside id="sidebar">
       <section class="projects">
@@ -17,19 +18,19 @@
       </section>
     </aside>
     <main id="chat">
-      <header>
-        <div class="spacer"></div>
-        <img src="carlton-logo.svg" id="logo" alt="Carlton logo">
-      </header>
-      <div id="messages"></div>
-      <form id="prompt-form">
-        <select id="model-select">
+      <header class="flex items-center p-2 bg-gray-900 border-b border-gray-700">
+        <img src="carlton-logo.svg" id="logo" alt="Carlton logo" class="w-10 h-10">
+        <div id="top-info" class="flex-1 text-sm text-gray-300"></div>
+        <select id="model-select" class="bg-gray-800 text-white border border-gray-600 rounded p-1">
           <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
           <option value="gpt-4">gpt-4</option>
         </select>
-        <input type="file" id="file-input" multiple>
-        <input type="text" id="prompt-input" placeholder="Type your message">
-        <button type="submit">Send</button>
+      </header>
+      <div id="messages" class="flex-1 p-4 overflow-y-auto"></div>
+      <form id="prompt-form" class="flex gap-2 p-2 bg-gray-900 border-t border-gray-700">
+        <input type="file" id="file-input" multiple class="text-sm text-gray-300">
+        <input type="text" id="prompt-input" placeholder="Type your message" class="flex-1 p-2 bg-gray-800 text-white border border-gray-600 rounded">
+        <button type="submit" class="p-2 bg-green-600 text-white rounded">Send</button>
       </form>
     </main>
   </div>

--- a/public/chat.js
+++ b/public/chat.js
@@ -10,7 +10,7 @@ const modelSelect = document.getElementById('model-select');
 let remainingQueries = parseInt(localStorage.getItem('remainingQueries') || '0');
 const queryLimit = document.createElement('div');
 queryLimit.id = 'query-limit';
-document.querySelector('header .spacer').appendChild(queryLimit);
+document.getElementById('top-info').appendChild(queryLimit);
 updateQueryDisplay();
 
 let currentProject = null;
@@ -74,16 +74,30 @@ promptForm.addEventListener('submit', async e => {
 function appendMessage(role, text) {
   const div = document.createElement('div');
   div.className = `message ${role}`;
-  if (/```/.test(text) || text.includes('\n')) {
-    const codeText = text.replace(/```/g, '');
+  const regex = /```([\s\S]*?)```/g;
+  let lastIndex = 0;
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    const before = text.slice(lastIndex, match.index).trim();
+    if (before) {
+      const p = document.createElement('p');
+      p.textContent = before;
+      div.appendChild(p);
+    }
+    const codeText = match[1];
     const pre = document.createElement('pre');
     const code = document.createElement('code');
-    code.textContent = codeText;
+    code.textContent = codeText.trim();
     pre.appendChild(code);
     div.appendChild(pre);
     hljs.highlightElement(code);
-  } else {
-    div.textContent = text;
+    lastIndex = regex.lastIndex;
+  }
+  const after = text.slice(lastIndex).trim();
+  if (after) {
+    const p = document.createElement('p');
+    p.textContent = after;
+    div.appendChild(p);
   }
   messagesDiv.appendChild(div);
   messagesDiv.scrollTop = messagesDiv.scrollHeight;

--- a/public/style.css
+++ b/public/style.css
@@ -119,6 +119,7 @@ header .spacer { flex: 1; }
   border: 1px solid #30363d;
   color: #f0f6fc;
   border-radius: 4px;
+  font-size: 15px;
 }
 #prompt-form button {
   padding: 0.5rem 1rem;


### PR DESCRIPTION
## Summary
- document default admin password for login
- style chat interface with Tailwind and move GPT model selector to header
- enlarge message input and wrap AI code responses in `<code>` blocks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf77003dc832bb2c59d95f7274af6