### PR TITLE
Add study mode and RSS-powered marquee with UI enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "dotenv": "^17.2.1",
         "express": "^4.18.2",
         "multer": "^1.4.5-lts.1",
-        "openai": "^4.0.0"
+        "openai": "^4.0.0",
+        "rss-parser": "^3.13.0"
       }
     },
     "node_modules/@types/node": {
@@ -326,6 +327,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -990,6 +1000,16 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/rss-parser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
+      "integrity": "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.0.3",
+        "xml2js": "^0.5.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1015,6 +1035,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
     },
     "node_modules/send": {
       "version": "0.19.0",
@@ -1276,6 +1302,28 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dotenv": "^17.2.1",
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1",
-    "openai": "^4.0.0"
+    "openai": "^4.0.0",
+    "rss-parser": "^3.13.0"
   }
 }

--- a/public/chat.html
+++ b/public/chat.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Carlton Chat</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark.min.css">
 </head>
@@ -11,14 +12,16 @@
   <div id="app">
     <aside id="sidebar">
       <section class="projects">
-        <h2>Projects</h2>
+        <h2><i class="fas fa-folder-open"></i> Projects</h2>
         <ul id="project-list"></ul>
-        <button id="new-project-btn">New Project</button>
-        <button id="open-codex">Open Codex</button>
+        <button id="new-project-btn"><i class="fas fa-folder-plus"></i> New Project</button>
+        <button id="open-codex"><i class="fas fa-book-open"></i> Open Codex</button>
+        <button id="study-mode-btn"><i class="fas fa-graduation-cap"></i> Study Mode</button>
       </section>
     </aside>
     <main id="chat">
       <header class="flex items-center p-2 bg-gray-900 border-b border-gray-700">
+        <button id="settings-btn" class="p-2 bg-gray-800 text-white rounded mr-2"><i class="fas fa-cog"></i></button>
         <img src="carlton-logo.svg" id="logo" alt="Carlton logo" class="w-10 h-10">
         <div id="top-info" class="flex-1 text-sm text-gray-300"></div>
         <select id="model-select" class="bg-gray-800 text-white border border-gray-600 rounded p-1">
@@ -28,11 +31,22 @@
       </header>
       <div id="messages" class="flex-1 p-4 overflow-y-auto"></div>
       <form id="prompt-form" class="flex gap-2 p-2 bg-gray-900 border-t border-gray-700">
-        <input type="file" id="file-input" multiple class="text-sm text-gray-300">
+        <label for="file-input" class="p-2 bg-gray-800 text-white rounded cursor-pointer"><i class="fas fa-paperclip"></i></label>
+        <input type="file" id="file-input" multiple class="hidden">
         <input type="text" id="prompt-input" placeholder="Type your message" class="flex-1 p-2 bg-gray-800 text-white border border-gray-600 rounded">
-        <button type="submit" class="p-2 bg-green-600 text-white rounded">Send</button>
+        <button type="submit" class="p-2 bg-green-600 text-white rounded"><i class="fas fa-paper-plane"></i> Send</button>
       </form>
+      <div id="rss-marquee" class="marquee bg-gray-800 text-white p-2 text-sm"></div>
     </main>
+  </div>
+  <div id="settings-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 items-center justify-center">
+    <div class="bg-gray-800 p-4 rounded">
+      <h3 class="mb-2 text-lg">Select RSS Feeds</h3>
+      <form id="settings-form" class="flex flex-col gap-2">
+        <div id="rss-options" class="flex flex-col gap-2"></div>
+        <button type="submit" class="p-2 bg-green-600 text-white rounded"><i class="fas fa-save"></i> Save</button>
+      </form>
+    </div>
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
   <script src="chat.js"></script>

--- a/public/chat.js
+++ b/public/chat.js
@@ -1,11 +1,25 @@
 const projectList = document.getElementById('project-list');
 const newProjectBtn = document.getElementById('new-project-btn');
 const openCodexBtn = document.getElementById('open-codex');
+const studyModeBtn = document.getElementById('study-mode-btn');
 const promptForm = document.getElementById('prompt-form');
 const promptInput = document.getElementById('prompt-input');
 const fileInput = document.getElementById('file-input');
 const messagesDiv = document.getElementById('messages');
 const modelSelect = document.getElementById('model-select');
+const settingsBtn = document.getElementById('settings-btn');
+const settingsModal = document.getElementById('settings-modal');
+const settingsForm = document.getElementById('settings-form');
+const rssOptions = document.getElementById('rss-options');
+const rssMarquee = document.getElementById('rss-marquee');
+
+const allFeeds = {
+  cnn: { name: 'CNN', url: 'https://rss.cnn.com/rss/cnn_topstories.rss' },
+  abc: { name: 'ABC', url: 'https://feeds.abcnews.com/abcnews/topstories' },
+  sports: { name: 'Sports', url: 'https://www.espn.com/espn/rss/news' }
+};
+let selectedFeeds = JSON.parse(localStorage.getItem('rssFeeds') || '["cnn","abc","sports"]');
+const studyData = [];
 
 let remainingQueries = parseInt(localStorage.getItem('remainingQueries') || '0');
 const queryLimit = document.createElement('div');
@@ -17,6 +31,23 @@ let currentProject = null;
 
 openCodexBtn.addEventListener('click', () => {
   window.open('codex.html', 'codexWindow');
+});
+
+studyModeBtn.addEventListener('click', () => {
+  const action = prompt('Type "add" to add info or "quiz" to start quiz');
+  if (action === 'add') {
+    const question = prompt('Enter a question or term');
+    const answer = prompt('Enter the answer');
+    if (question && answer) studyData.push({ question, answer });
+  } else if (action === 'quiz') {
+    if (!studyData.length) {
+      alert('No study data yet');
+      return;
+    }
+    const item = studyData[Math.floor(Math.random() * studyData.length)];
+    const resp = prompt(item.question);
+    alert(resp === item.answer ? 'Correct!' : `Incorrect. ${item.answer}`);
+  }
 });
 
 newProjectBtn.addEventListener('click', async () => {
@@ -35,6 +66,21 @@ projectList.addEventListener('click', e => {
     currentProject = e.target.dataset.id;
     loadProjectHistory();
   }
+});
+
+settingsBtn.addEventListener('click', () => {
+  renderSettings();
+  settingsModal.classList.remove('hidden');
+  settingsModal.classList.add('flex');
+});
+
+settingsForm.addEventListener('submit', e => {
+  e.preventDefault();
+  selectedFeeds = Array.from(rssOptions.querySelectorAll('input:checked')).map(cb => cb.value);
+  localStorage.setItem('rssFeeds', JSON.stringify(selectedFeeds));
+  settingsModal.classList.add('hidden');
+  settingsModal.classList.remove('flex');
+  updateMarquee();
 });
 
 promptForm.addEventListener('submit', async e => {
@@ -128,7 +174,41 @@ async function loadProjectHistory() {
 }
 
 loadProjects();
+updateMarquee();
 
 function updateQueryDisplay() {
   queryLimit.textContent = `Queries left: ${remainingQueries}`;
+}
+
+function renderSettings() {
+  rssOptions.innerHTML = '';
+  Object.entries(allFeeds).forEach(([key, feed]) => {
+    const label = document.createElement('label');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = key;
+    if (selectedFeeds.includes(key)) checkbox.checked = true;
+    label.appendChild(checkbox);
+    label.append(' ' + feed.name);
+    rssOptions.appendChild(label);
+  });
+}
+
+async function updateMarquee() {
+  const titles = [];
+  for (const key of selectedFeeds) {
+    const url = allFeeds[key].url;
+    try {
+      const res = await fetch(`/api/rss?url=${encodeURIComponent(url)}`);
+      const json = await res.json();
+      titles.push(...json.titles.slice(0, 5));
+    } catch (err) {
+      console.error(err);
+    }
+  }
+  const content = document.createElement('div');
+  content.className = 'marquee-content';
+  content.innerHTML = titles.map(t => `<span>${t}</span>`).join('');
+  rssMarquee.innerHTML = '';
+  rssMarquee.appendChild(content);
 }

--- a/public/style.css
+++ b/public/style.css
@@ -3,6 +3,7 @@ body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background: #0d1117;
   color: #f0f6fc;
+  font-size: 16px;
 }
 
 /* Landing page */
@@ -104,6 +105,9 @@ header .spacer { flex: 1; }
 .message { margin-bottom: 1rem; }
 .message.user { color: #79c0ff; }
 .message.bot { color: #ffa657; }
+.message.bot::before {
+  content: '🤖 ';
+}
 
 #prompt-form {
   display: flex;
@@ -130,6 +134,23 @@ header .spacer { flex: 1; }
   cursor: pointer;
 }
 #prompt-form button:hover { background: #2ea043; }
+
+.marquee {
+  overflow: hidden;
+  white-space: nowrap;
+}
+.marquee-content {
+  display: inline-block;
+  padding-left: 100%;
+  animation: marquee 20s linear infinite;
+}
+.marquee-content span {
+  padding-right: 2rem;
+}
+@keyframes marquee {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-100%); }
+}
 
 pre {
   background: #0d1117;

--- a/server.js
+++ b/server.js
@@ -4,7 +4,8 @@ import fs from 'fs';
 import path from 'path';
 import multer from 'multer';
 import OpenAI from 'openai';
-import 'dotenv/config';    
+import Parser from 'rss-parser';
+import 'dotenv/config';
 import { slugify, generateTitle } from './utils.js';
 
 const app = express();
@@ -13,6 +14,7 @@ app.use(express.json());
 app.use(express.static('public'));
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const parser = new Parser();
 
 const DATA_DIR = path.join(process.cwd(), 'data');
 const PROJECTS_DIR = path.join(DATA_DIR, 'projects');
@@ -86,7 +88,14 @@ app.post('/api/projects/:projectId/chat', upload.array('files'), async (req, res
   try {
     const completion = await openai.chat.completions.create({
       model,
-      messages: [{ role: 'user', content: prompt }]
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are Carlton, an AI assistant. Answer the user and end your response with an additional suggestion to take it to the next level.'
+        },
+        { role: 'user', content: prompt }
+      ]
     });
     responseText = completion.choices[0].message.content.trim();
   } catch (err) {
@@ -104,6 +113,18 @@ app.post('/api/projects/:projectId/chat', upload.array('files'), async (req, res
   const chatPath = path.join(PROJECTS_DIR, projectId, file);
   fs.writeFileSync(chatPath, JSON.stringify(chatData, null, 2));
   res.json({ ...chatData, id: file });
+});
+
+app.get('/api/rss', async (req, res) => {
+  const { url } = req.query;
+  if (!url) return res.status(400).json({ error: 'url required' });
+  try {
+    const feed = await parser.parseURL(url);
+    const titles = feed.items.map(i => i.title);
+    res.json({ titles });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 });
 
 // Standalone Codex endpoint using chat completions


### PR DESCRIPTION
## Summary
- Make AI replies include next-level suggestion and display robot emoji
- Introduce study mode button, settings menu, and RSS marquee with selectable feeds
- Apply uniform 16px font and add icons and settings button to interface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adfd758c24832b90fcbc2ac8463a1f