### PR TITLE
Enhance news ticker and chat UI

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -36,7 +36,10 @@
         <input type="text" id="prompt-input" placeholder="Type your message" class="flex-1 p-2 bg-gray-800 text-white border border-gray-600 rounded">
         <button type="submit" class="p-2 bg-green-600 text-white rounded"><i class="fas fa-paper-plane"></i> Send</button>
       </form>
-      <div id="rss-marquee" class="marquee bg-gray-800 text-white p-2 text-sm"></div>
+      <div id="rss-ticker" class="flex items-center bg-gray-800 text-white text-sm">
+        <span class="ticker-label px-2 py-1 bg-gray-700">PayneBrain News Ticker</span>
+        <div id="rss-marquee" class="marquee p-2 flex-1"></div>
+      </div>
     </main>
   </div>
   <div id="settings-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 items-center justify-center">

--- a/public/chat.js
+++ b/public/chat.js
@@ -120,6 +120,8 @@ promptForm.addEventListener('submit', async e => {
 function appendMessage(role, text) {
   const div = document.createElement('div');
   div.className = `message ${role}`;
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble';
   const regex = /```([\s\S]*?)```/g;
   let lastIndex = 0;
   let match;
@@ -128,14 +130,14 @@ function appendMessage(role, text) {
     if (before) {
       const p = document.createElement('p');
       p.textContent = before;
-      div.appendChild(p);
+      bubble.appendChild(p);
     }
     const codeText = match[1];
     const pre = document.createElement('pre');
     const code = document.createElement('code');
     code.textContent = codeText.trim();
     pre.appendChild(code);
-    div.appendChild(pre);
+    bubble.appendChild(pre);
     hljs.highlightElement(code);
     lastIndex = regex.lastIndex;
   }
@@ -143,7 +145,16 @@ function appendMessage(role, text) {
   if (after) {
     const p = document.createElement('p');
     p.textContent = after;
-    div.appendChild(p);
+    bubble.appendChild(p);
+  }
+  if (role === 'bot') {
+    const icon = document.createElement('div');
+    icon.className = 'icon-bubble';
+    icon.textContent = '🤖';
+    div.appendChild(icon);
+    div.appendChild(bubble);
+  } else {
+    div.appendChild(bubble);
   }
   messagesDiv.appendChild(div);
   messagesDiv.scrollTop = messagesDiv.scrollHeight;
@@ -201,7 +212,7 @@ async function updateMarquee() {
     try {
       const res = await fetch(`/api/rss?url=${encodeURIComponent(url)}`);
       const json = await res.json();
-      titles.push(...json.titles.slice(0, 5));
+      titles.push(...json.titles);
     } catch (err) {
       console.error(err);
     }

--- a/public/style.css
+++ b/public/style.css
@@ -166,7 +166,7 @@ header .spacer { flex: 1; }
 .marquee-content {
   display: inline-block;
   padding-left: 100%;
-  animation: marquee 30s linear infinite;
+  animation: marquee 500s linear infinite;
 }
 .marquee-content span {
   padding-right: 2rem;

--- a/public/style.css
+++ b/public/style.css
@@ -60,7 +60,8 @@ body {
 }
 
 #sidebar {
-  width: 260px;
+  width: 300px;
+  min-width: 300px;
   background: #161b22;
   padding: 1rem;
   overflow-y: auto;
@@ -102,11 +103,34 @@ header .spacer { flex: 1; }
   padding: 1rem;
   overflow-y: auto;
 }
-.message { margin-bottom: 1rem; }
-.message.user { color: #79c0ff; }
-.message.bot { color: #ffa657; }
-.message.bot::before {
-  content: '🤖 ';
+.message {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+.message.user {
+  color: #79c0ff;
+  justify-content: flex-end;
+}
+.message.bot {
+  color: #ffa657;
+  justify-content: flex-start;
+  align-items: flex-start;
+}
+.bubble {
+  background: #161b22;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+}
+.icon-bubble {
+  background: #161b22;
+  padding: 0.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  width: 32px;
 }
 
 #prompt-form {
@@ -142,10 +166,16 @@ header .spacer { flex: 1; }
 .marquee-content {
   display: inline-block;
   padding-left: 100%;
-  animation: marquee 20s linear infinite;
+  animation: marquee 30s linear infinite;
 }
 .marquee-content span {
   padding-right: 2rem;
+  position: relative;
+}
+.marquee-content span::before {
+  content: '\2022';
+  color: red;
+  margin-right: 0.5rem;
 }
 @keyframes marquee {
   0% { transform: translateX(0); }
@@ -157,6 +187,13 @@ pre {
   padding: 0.5rem;
   overflow-x: auto;
   border-radius: 4px;
+  border: 1px solid #fff;
+  box-shadow: 0 0 10px dodgerblue;
+}
+
+.ticker-label {
+  font-weight: bold;
+  margin-right: 1rem;
 }
 
 /* Codex window */


### PR DESCRIPTION
## Summary
- Expand sidebar to 300px and refine message layout with bubbles and bot icon
- Slow RSS ticker, add red dots and PayneBrain label, and include all feed headlines
- Style code blocks with white border and dodgerblue shadow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae014307a0832b9ba5fa82656b4516