### PR TITLE
Add weather widget and image-aware chat

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -24,7 +24,9 @@
         <button id="settings-btn" class="p-2 bg-gray-800 text-white rounded mr-2"><i class="fas fa-cog"></i></button>
         <img src="carlton-logo.svg" id="logo" alt="Carlton logo" class="w-10 h-10">
         <div id="top-info" class="flex-1 text-sm text-gray-300"></div>
+        <div id="weather" class="flex items-center text-sm text-gray-300 mr-2"></div>
         <select id="model-select" class="bg-gray-800 text-white border border-gray-600 rounded p-1">
+          <option value="gpt-4o-mini">gpt-4o-mini</option>
           <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
           <option value="gpt-4">gpt-4</option>
         </select>
@@ -44,9 +46,12 @@
   </div>
   <div id="settings-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 items-center justify-center">
     <div class="bg-gray-800 p-4 rounded">
-      <h3 class="mb-2 text-lg">Select RSS Feeds</h3>
+      <h3 class="mb-2 text-lg">Settings</h3>
       <form id="settings-form" class="flex flex-col gap-2">
         <div id="rss-options" class="flex flex-col gap-2"></div>
+        <label class="flex items-center gap-2">Zip Code
+          <input type="text" id="zip-input" class="p-1 bg-gray-700 text-white rounded w-24" placeholder="e.g. 10001">
+        </label>
         <button type="submit" class="p-2 bg-green-600 text-white rounded"><i class="fas fa-save"></i> Save</button>
       </form>
     </div>

--- a/public/chat.js
+++ b/public/chat.js
@@ -12,6 +12,8 @@ const settingsModal = document.getElementById('settings-modal');
 const settingsForm = document.getElementById('settings-form');
 const rssOptions = document.getElementById('rss-options');
 const rssMarquee = document.getElementById('rss-marquee');
+const zipInput = document.getElementById('zip-input');
+const weatherDiv = document.getElementById('weather');
 
 const allFeeds = {
   cnn: { name: 'CNN', url: 'https://rss.cnn.com/rss/cnn_topstories.rss' },
@@ -19,6 +21,7 @@ const allFeeds = {
   sports: { name: 'Sports', url: 'https://www.espn.com/espn/rss/news' }
 };
 let selectedFeeds = JSON.parse(localStorage.getItem('rssFeeds') || '["cnn","abc","sports"]');
+let userZip = localStorage.getItem('zip') || '';
 const studyData = [];
 
 let remainingQueries = parseInt(localStorage.getItem('remainingQueries') || '0');
@@ -78,9 +81,12 @@ settingsForm.addEventListener('submit', e => {
   e.preventDefault();
   selectedFeeds = Array.from(rssOptions.querySelectorAll('input:checked')).map(cb => cb.value);
   localStorage.setItem('rssFeeds', JSON.stringify(selectedFeeds));
+  userZip = zipInput.value.trim();
+  localStorage.setItem('zip', userZip);
   settingsModal.classList.add('hidden');
   settingsModal.classList.remove('flex');
   updateMarquee();
+  updateWeather();
 });
 
 promptForm.addEventListener('submit', async e => {
@@ -102,7 +108,7 @@ promptForm.addEventListener('submit', async e => {
     currentProject = proj.id;
     loadProjects();
   }
-  appendMessage('user', prompt);
+  appendMessage('user', prompt, Array.from(fileInput.files));
   const data = new FormData();
   data.append('prompt', prompt);
   data.append('model', modelSelect.value);
@@ -117,7 +123,7 @@ promptForm.addEventListener('submit', async e => {
   updateQueryDisplay();
 });
 
-function appendMessage(role, text) {
+function appendMessage(role, text, attachments = []) {
   const div = document.createElement('div');
   div.className = `message ${role}`;
   const bubble = document.createElement('div');
@@ -146,6 +152,34 @@ function appendMessage(role, text) {
     const p = document.createElement('p');
     p.textContent = after;
     bubble.appendChild(p);
+  }
+  if (attachments.length) {
+    const atDiv = document.createElement('div');
+    atDiv.className = 'attachments mt-2 flex flex-wrap gap-2';
+    attachments.forEach(file => {
+      if (file instanceof File) {
+        const url = URL.createObjectURL(file);
+        if (file.type.startsWith('image/')) {
+          const img = document.createElement('img');
+          img.src = url;
+          img.alt = file.name;
+          img.className = 'attachment-img';
+          atDiv.appendChild(img);
+        } else {
+          const link = document.createElement('a');
+          link.href = url;
+          link.textContent = file.name;
+          link.className = 'attachment-link underline';
+          link.target = '_blank';
+          atDiv.appendChild(link);
+        }
+      } else if (file && file.original) {
+        const span = document.createElement('span');
+        span.textContent = file.original;
+        atDiv.appendChild(span);
+      }
+    });
+    bubble.appendChild(atDiv);
   }
   if (role === 'bot') {
     const icon = document.createElement('div');
@@ -179,7 +213,7 @@ async function loadProjectHistory() {
   for (const c of chats) {
     const resChat = await fetch(`/api/projects/${currentProject}/chats/${c.id}`);
     const chat = await resChat.json();
-    appendMessage('user', chat.prompt);
+    appendMessage('user', chat.prompt, chat.files || []);
     appendMessage('bot', chat.response);
   }
 }
@@ -203,6 +237,7 @@ function renderSettings() {
     label.append(' ' + feed.name);
     rssOptions.appendChild(label);
   });
+  zipInput.value = userZip;
 }
 
 async function updateMarquee() {
@@ -223,3 +258,24 @@ async function updateMarquee() {
   rssMarquee.innerHTML = '';
   rssMarquee.appendChild(content);
 }
+
+async function updateWeather() {
+  if (!userZip) {
+    weatherDiv.textContent = '';
+    return;
+  }
+  try {
+    const res = await fetch(`https://wttr.in/${userZip}?format=j1`);
+    const data = await res.json();
+    const current = data.current_condition[0];
+    const humidity = parseInt(current.humidity);
+    const iconUrl = current.weatherIconUrl[0].value;
+    weatherDiv.style.color = humidity < 55 ? 'limegreen' : '';
+    weatherDiv.innerHTML = `<img src="${iconUrl}" alt="icon" class="w-6 h-6 mr-1">${current.temp_F}\u00B0F` + (humidity < 55 ? ' <span>Perfect Day</span>' : '');
+  } catch (e) {
+    console.error(e);
+    weatherDiv.textContent = '';
+  }
+}
+
+updateWeather();

--- a/public/style.css
+++ b/public/style.css
@@ -102,6 +102,7 @@ header .spacer { flex: 1; }
   flex: 1;
   padding: 1rem;
   overflow-y: auto;
+  font-size: 18px;
 }
 .message {
   margin-bottom: 1rem;
@@ -121,6 +122,8 @@ header .spacer { flex: 1; }
   background: #161b22;
   padding: 0.5rem 0.75rem;
   border-radius: 8px;
+  max-width: 80%;
+  word-break: break-word;
 }
 .icon-bubble {
   background: #161b22;
@@ -147,7 +150,7 @@ header .spacer { flex: 1; }
   border: 1px solid #30363d;
   color: #f0f6fc;
   border-radius: 4px;
-  font-size: 15px;
+  font-size: 18px;
 }
 #prompt-form button {
   padding: 0.5rem 1rem;
@@ -187,8 +190,14 @@ pre {
   padding: 0.5rem;
   overflow-x: auto;
   border-radius: 4px;
-  border: 1px solid #fff;
+  border: 2px solid #fff;
   box-shadow: 0 0 10px dodgerblue;
+  font-size: 16px;
+}
+
+.attachment-img {
+  max-width: 200px;
+  border-radius: 4px;
 }
 
 .ticker-label {

--- a/server.js
+++ b/server.js
@@ -86,16 +86,26 @@ app.post('/api/projects/:projectId/chat', upload.array('files'), async (req, res
 
   let responseText = '';
   try {
+    const sys = {
+      role: 'system',
+      content: 'You are Carlton, an AI assistant. Answer the user and end your response with an additional suggestion to take it to the next level.'
+    };
+    let userMessage;
+    if (req.files && req.files.length) {
+      const parts = [{ type: 'text', text: prompt }];
+      for (const f of req.files) {
+        if (f.mimetype && f.mimetype.startsWith('image/')) {
+          const b64 = fs.readFileSync(f.path, { encoding: 'base64' });
+          parts.push({ type: 'image', image_url: `data:${f.mimetype};base64,${b64}` });
+        }
+      }
+      userMessage = { role: 'user', content: parts };
+    } else {
+      userMessage = { role: 'user', content: prompt };
+    }
     const completion = await openai.chat.completions.create({
       model,
-      messages: [
-        {
-          role: 'system',
-          content:
-            'You are Carlton, an AI assistant. Answer the user and end your response with an additional suggestion to take it to the next level.'
-        },
-        { role: 'user', content: prompt }
-      ]
+      messages: [sys, userMessage]
     });
     responseText = completion.choices[0].message.content.trim();
   } catch (err) {


### PR DESCRIPTION
## Summary
- display current weather with icon and optional "Perfect Day" notice when humidity is low
- allow users to enter a ZIP code in settings to fetch weather
- preview and forward uploaded images/files; send images to OpenAI for analysis
- enlarge chat fonts and code block styling for better readability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae0508f8a4832b97eaba61f6afe7c0