### PR TITLE
Add user RSS feeds, icons, and UI tweaks

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -29,6 +29,7 @@
           <option value="gpt-4o-mini">gpt-4o-mini</option>
           <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
           <option value="gpt-4">gpt-4</option>
+          <option value="gpt-5">gpt-5</option>
         </select>
       </header>
       <div id="messages" class="flex-1 p-4 overflow-y-auto"></div>
@@ -50,6 +51,11 @@
       <h3 class="mb-2 text-base">Settings</h3>
       <form id="settings-form" class="flex flex-col gap-2">
         <div id="rss-options" class="flex flex-col gap-2"></div>
+        <div id="custom-rss" class="flex flex-col gap-2">
+          <input type="text" id="custom-rss-name" class="p-1 bg-gray-700 text-white rounded" placeholder="Feed Name">
+          <input type="text" id="custom-rss-url" class="p-1 bg-gray-700 text-white rounded" placeholder="Feed URL">
+          <button type="button" id="add-rss-btn" class="p-2 bg-blue-600 text-white rounded"><i class="fas fa-plus"></i> Add Feed</button>
+        </div>
         <label class="flex items-center gap-2">Zip Code
           <input type="text" id="zip-input" class="p-1 bg-gray-700 text-white rounded w-24" placeholder="e.g. 10001">
         </label>

--- a/public/chat.js
+++ b/public/chat.js
@@ -14,12 +14,16 @@ const rssOptions = document.getElementById('rss-options');
 const rssMarquee = document.getElementById('rss-marquee');
 const zipInput = document.getElementById('zip-input');
 const weatherDiv = document.getElementById('weather');
+const customRssName = document.getElementById('custom-rss-name');
+const customRssUrl = document.getElementById('custom-rss-url');
+const addRssBtn = document.getElementById('add-rss-btn');
 
 const allFeeds = {
   cnn: { name: 'CNN', url: 'https://rss.cnn.com/rss/cnn_topstories.rss' },
   abc: { name: 'ABC', url: 'https://feeds.abcnews.com/abcnews/topstories' },
   sports: { name: 'Sports', url: 'https://www.espn.com/espn/rss/news' }
 };
+const customFeeds = JSON.parse(localStorage.getItem('customFeeds') || '{}');
 let selectedFeeds = JSON.parse(localStorage.getItem('rssFeeds') || '["cnn","abc","sports"]');
 let userZip = localStorage.getItem('zip') || '';
 const studyData = [];
@@ -87,6 +91,21 @@ settingsForm.addEventListener('submit', e => {
   settingsModal.classList.remove('flex');
   updateMarquee();
   updateWeather();
+});
+
+addRssBtn.addEventListener('click', () => {
+  const name = customRssName.value.trim();
+  const url = customRssUrl.value.trim();
+  if (!name || !url) return;
+  const key = 'user_' + Date.now();
+  customFeeds[key] = { name, url };
+  localStorage.setItem('customFeeds', JSON.stringify(customFeeds));
+  selectedFeeds.push(key);
+  localStorage.setItem('rssFeeds', JSON.stringify(selectedFeeds));
+  customRssName.value = '';
+  customRssUrl.value = '';
+  renderSettings();
+  updateMarquee();
 });
 
 promptForm.addEventListener('submit', async e => {
@@ -195,7 +214,11 @@ function appendMessage(role, text, attachments = []) {
     div.appendChild(icon);
     div.appendChild(bubble);
   } else {
+    const icon = document.createElement('div');
+    icon.className = 'icon-bubble';
+    icon.textContent = '👤';
     div.appendChild(bubble);
+    div.appendChild(icon);
   }
   messagesDiv.appendChild(div);
   messagesDiv.scrollTop = messagesDiv.scrollHeight;
@@ -234,7 +257,8 @@ function updateQueryDisplay() {
 
 function renderSettings() {
   rssOptions.innerHTML = '';
-  Object.entries(allFeeds).forEach(([key, feed]) => {
+  const feeds = { ...allFeeds, ...customFeeds };
+  Object.entries(feeds).forEach(([key, feed]) => {
     const label = document.createElement('label');
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
@@ -249,10 +273,12 @@ function renderSettings() {
 
 async function updateMarquee() {
   const titles = [];
+  const feeds = { ...allFeeds, ...customFeeds };
   for (const key of selectedFeeds) {
-    const url = allFeeds[key].url;
+    const feed = feeds[key];
+    if (!feed) continue;
     try {
-      const res = await fetch(`/api/rss?url=${encodeURIComponent(url)}`);
+      const res = await fetch(`/api/rss?url=${encodeURIComponent(feed.url)}`);
       const json = await res.json();
       titles.push(...json.titles);
     } catch (err) {

--- a/public/style.css
+++ b/public/style.css
@@ -153,6 +153,7 @@ header{
   gap: 0.75rem;
   scrollbar-width: thin;
   scrollbar-color: #30363d transparent;
+  font-size: 1.25rem;
 }
 #messages::-webkit-scrollbar{ height: 8px; width: 8px; }
 #messages::-webkit-scrollbar-thumb{ background:#30363d; border-radius: 8px; }
@@ -161,6 +162,7 @@ header{
 /* Message rows (already flex); add subtle in/out animation */
 .message{
   width: 100%;
+  display: flex;
   gap: 0.5rem;
   animation: msgPop .18s ease-out;
 }
@@ -308,6 +310,9 @@ pre{
 }
 #rss-ticker {
   font-size: 16px;
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
 }
 .marquee-content span {
   padding-right: 2rem;

--- a/server.js
+++ b/server.js
@@ -96,7 +96,7 @@ app.post('/api/projects/:projectId/chat', upload.array('files'), async (req, res
       for (const f of req.files) {
         if (f.mimetype && f.mimetype.startsWith('image/')) {
           const b64 = fs.readFileSync(f.path, { encoding: 'base64' });
-          parts.push({ type: 'image', image_url: `data:${f.mimetype};base64,${b64}` });
+          parts.push({ type: 'image_url', image_url: `data:${f.mimetype};base64,${b64}` });
         }
       }
       userMessage = { role: 'user', content: parts };


### PR DESCRIPTION
## Summary
- Keep news ticker fixed at the bottom and enlarge chat font for readability
- Allow custom RSS feeds via settings and show a user icon beside messages
- Fix image handling for chat responses and add new `gpt-5` model option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae539bdae4832b81ac7acfc93604fe