### PR TITLE
Display OpenAI balance and highlight active project

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -31,6 +31,7 @@
           <option value="gpt-4">gpt-4</option>
           <option value="gpt-5">gpt-5</option>
         </select>
+        <span id="balance" class="ml-2 text-sm text-gray-300"></span>
       </header>
       <div id="messages" class="flex-1 p-4 overflow-y-auto"></div>
       <form id="prompt-form" class="flex gap-2 p-2 bg-gray-900 border-t border-gray-700">

--- a/public/chat.js
+++ b/public/chat.js
@@ -7,6 +7,7 @@ const promptInput = document.getElementById('prompt-input');
 const fileInput = document.getElementById('file-input');
 const messagesDiv = document.getElementById('messages');
 const modelSelect = document.getElementById('model-select');
+const balanceSpan = document.getElementById('balance');
 const settingsBtn = document.getElementById('settings-btn');
 const settingsModal = document.getElementById('settings-modal');
 const settingsForm = document.getElementById('settings-form');
@@ -36,6 +37,18 @@ updateQueryDisplay();
 
 let currentProject = null;
 
+async function updateBalance() {
+  try {
+    const res = await fetch('/api/balance');
+    const data = await res.json();
+    balanceSpan.textContent = `Balance: $${parseFloat(data.balance).toFixed(2)}`;
+  } catch (e) {
+    balanceSpan.textContent = 'Balance: N/A';
+  }
+}
+updateBalance();
+setInterval(updateBalance, 60000);
+
 openCodexBtn.addEventListener('click', () => {
   window.open('codex.html', 'codexWindow');
 });
@@ -60,17 +73,21 @@ studyModeBtn.addEventListener('click', () => {
 newProjectBtn.addEventListener('click', async () => {
   const name = prompt('Project name');
   if (!name) return;
-  await fetch('/api/projects', {
+  const resProj = await fetch('/api/projects', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name })
   });
+  const proj = await resProj.json();
+  currentProject = proj.id;
   loadProjects();
 });
 
 projectList.addEventListener('click', e => {
   if (e.target.tagName === 'LI') {
     currentProject = e.target.dataset.id;
+    projectList.querySelectorAll('li').forEach(li => li.classList.remove('selected'));
+    e.target.classList.add('selected');
     loadProjectHistory();
   }
 });
@@ -232,6 +249,7 @@ async function loadProjects() {
     const li = document.createElement('li');
     li.textContent = p.name;
     li.dataset.id = p.id;
+    if (p.id === currentProject) li.classList.add('selected');
     projectList.appendChild(li);
   });
 }

--- a/public/start.js
+++ b/public/start.js
@@ -1,26 +1,78 @@
-const svg = d3.select('#bg')
-  .attr('width', window.innerWidth)
-  .attr('height', window.innerHeight);
+const width = window.innerWidth;
+const height = window.innerHeight;
 
-const nodes = d3.range(30).map(() => ({ r: Math.random() * 10 + 5 }));
+const svg = d3.select('#bg')
+  .attr('width', width)
+  .attr('height', height);
+
+const nodes = d3.range(40).map(() => ({ r: Math.random() * 6 + 4 }));
+const links = d3.range(nodes.length).map(() => ({
+  source: Math.floor(Math.random() * nodes.length),
+  target: Math.floor(Math.random() * nodes.length)
+}));
 
 const simulation = d3.forceSimulation(nodes)
-  .force('charge', d3.forceManyBody().strength(5))
-  .force('center', d3.forceCenter(window.innerWidth / 2, window.innerHeight / 2))
+  .force('link', d3.forceLink(links).distance(40).strength(0.5))
+  .force('charge', d3.forceManyBody().strength(-30))
+  .force('center', d3.forceCenter(width / 2, height / 2))
   .force('collision', d3.forceCollide().radius(d => d.r + 1))
   .on('tick', ticked);
 
-const circles = svg.selectAll('circle')
+const link = svg.append('g')
+  .attr('stroke', 'rgba(255,255,255,0.15)')
+  .selectAll('line')
+  .data(links)
+  .enter().append('line');
+
+const node = svg.append('g')
+  .selectAll('circle')
   .data(nodes)
-  .enter()
-  .append('circle')
+  .enter().append('circle')
   .attr('r', d => d.r)
-  .attr('fill', 'rgba(255,255,255,0.5)');
+  .attr('fill', (_, i) => d3.interpolateRainbow(i / nodes.length))
+  .call(d3.drag()
+    .on('start', dragstarted)
+    .on('drag', dragged)
+    .on('end', dragended)
+  );
 
 function ticked() {
-  circles.attr('cx', d => d.x)
+  link
+    .attr('x1', d => d.source.x)
+    .attr('y1', d => d.source.y)
+    .attr('x2', d => d.target.x)
+    .attr('y2', d => d.target.y);
+  node
+    .attr('cx', d => d.x)
     .attr('cy', d => d.y);
 }
+
+function dragstarted(event) {
+  if (!event.active) simulation.alphaTarget(0.3).restart();
+  event.subject.fx = event.subject.x;
+  event.subject.fy = event.subject.y;
+}
+
+function dragged(event) {
+  event.subject.fx = event.x;
+  event.subject.fy = event.y;
+}
+
+function dragended(event) {
+  if (!event.active) simulation.alphaTarget(0);
+  event.subject.fx = null;
+  event.subject.fy = null;
+}
+
+svg.on('mousemove', (event) => {
+  const [x, y] = d3.pointer(event);
+  simulation.force('center', d3.forceCenter(x, y));
+  simulation.alphaTarget(0.1).restart();
+});
+
+d3.interval(() => {
+  node.attr('fill', (_, i) => d3.interpolateRainbow((Date.now()/5000 + i/nodes.length) % 1));
+}, 100);
 
 function login(user) {
   localStorage.setItem('user', user);

--- a/public/style.css
+++ b/public/style.css
@@ -127,6 +127,11 @@ h1, h2, h3, h4, h5, h6 {
   background: #2d333b;
 }
 
+#project-list li.selected{
+  background: yellow;
+  color: #000;
+}
+
 /* Chat area flows to the right via margin (no flex/grid on #app) */
 #chat{
   margin-left: 300px;      /* sits to the right of fixed sidebar */

--- a/server.js
+++ b/server.js
@@ -137,6 +137,18 @@ app.get('/api/rss', async (req, res) => {
   }
 });
 
+app.get('/api/balance', async (req, res) => {
+  try {
+    const resp = await fetch('https://api.openai.com/v1/dashboard/billing/credit_grants', {
+      headers: { Authorization: `Bearer ${process.env.OPENAI_API_KEY}` }
+    });
+    const data = await resp.json();
+    res.json({ balance: data.total_available });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Standalone Codex endpoint using chat completions
 app.post('/api/codex', async (req, res) => {
   const { prompt } = req.body;


### PR DESCRIPTION
## Summary
- show real-time OpenAI account balance beside model picker
- highlight selected project in yellow and auto-select new projects
- replace login page background with interactive D3 node network

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae577aa910832b9cd265165604905f