### PR TITLE
Animate chat bubbles and mobile ticker

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -25,6 +25,7 @@
       <header class="flex items-center p-2 bg-gray-900 border-b border-gray-700 text-base">
         <button id="settings-btn" class="p-2 bg-gray-800 text-white rounded mr-2"><i class="fas fa-cog"></i></button>
         <img src="carlton-logo.svg" id="logo" alt="Carlton logo" class="w-10 h-10">
+        <h1 id="main-title" class="text-xl font-bold mx-2">Hey! Carlton</h1>
         <div id="top-info" class="flex-1 text-gray-300"></div>
         <select id="model-select" class="bg-gray-800 text-white border border-gray-600 rounded p-1">
           <option value="gpt-4o-mini">gpt-4o-mini</option>

--- a/public/chat.js
+++ b/public/chat.js
@@ -15,6 +15,22 @@ const rssOptions = document.getElementById('rss-options');
 const rssMarquee = document.getElementById('rss-marquee');
 const zipInput = document.getElementById('zip-input');
 const weatherDiv = document.getElementById('weather');
+const tickerLabel = document.querySelector('.ticker-label');
+
+function updateTickerLabel() {
+  if (window.matchMedia('(max-width: 600px)').matches) {
+    tickerLabel.textContent = 'PNT:';
+  } else {
+    tickerLabel.textContent = 'PayneBrain News Ticker';
+  }
+}
+window.addEventListener('resize', updateTickerLabel);
+updateTickerLabel();
+
+function getFlyInClass() {
+  const dirs = ['fly-in-left', 'fly-in-right', 'fly-in-top', 'fly-in-bottom'];
+  return dirs[Math.floor(Math.random() * dirs.length)];
+}
 
 const allFeeds = {
   cnn: { name: 'CNN', url: 'https://rss.cnn.com/rss/cnn_topstories.rss' },
@@ -150,6 +166,7 @@ function appendMessage(role, text, attachments = []) {
   div.className = `message ${role}`;
   const bubble = document.createElement('div');
   bubble.className = 'bubble';
+  bubble.classList.add(getFlyInClass());
   const regex = /```([\s\S]*?)```/g;
   let lastIndex = 0;
   let match;
@@ -315,6 +332,7 @@ function showThinking() {
   icon.textContent = '🤖';
   const bubble = document.createElement('div');
   bubble.className = 'bubble';
+  bubble.classList.add(getFlyInClass());
   const img = document.createElement('img');
   img.src = 'https://media.tenor.com/I6kN-6X7nhAAAAAj/loading-buffering.gif';
   img.alt = 'thinking';

--- a/public/style.css
+++ b/public/style.css
@@ -184,7 +184,33 @@ header{
   box-shadow:
     0 1px 0 rgba(255,255,255,.05) inset,
     0 6px 20px rgba(0,0,0,.25);
+  opacity: 0;
 }
+
+@keyframes fly-in-left {
+  from { transform: translateX(-50px); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes fly-in-right {
+  from { transform: translateX(50px); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes fly-in-top {
+  from { transform: translateY(-50px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes fly-in-bottom {
+  from { transform: translateY(50px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.bubble.fly-in-left { animation: fly-in-left 1s ease-out forwards; }
+.bubble.fly-in-right { animation: fly-in-right 1s ease-out forwards; }
+.bubble.fly-in-top { animation: fly-in-top 1s ease-out forwards; }
+.bubble.fly-in-bottom { animation: fly-in-bottom 1s ease-out forwards; }
 
 /* Left (bot) bubble + tail */
 .message.bot .bubble{


### PR DESCRIPTION
## Summary
- Add prominent "Hey! Carlton" header title
- Animate chat bubbles with random fly-in directions
- Adjust news ticker label to "PNT:" on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae623eefc0832bba59ca46d86afa56