### PR TITLE
Animate landing page with bouncing canvas nodes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
   <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
 <body>
-  <svg id="bg"></svg>
+  <canvas id="bg"></canvas>
   <div id="landing">
     <h1>Whatcha Wanna Talk About?</h1>
     <div id="login">

--- a/public/start.js
+++ b/public/start.js
@@ -1,72 +1,35 @@
-const width = window.innerWidth;
-const height = window.innerHeight;
+const canvas = document.getElementById('bg');
+const ctx = canvas.getContext('2d');
 
-const svg = d3.select('#bg')
-  .attr('width', width)
-  .attr('height', height);
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+resize();
+window.addEventListener('resize', resize);
 
-const nodes = d3.range(40).map(() => ({ r: Math.random() * 6 + 4 }));
-const links = d3.range(nodes.length).map(() => ({
-  source: Math.floor(Math.random() * nodes.length),
-  target: Math.floor(Math.random() * nodes.length)
+const nodes = d3.range(100).map(() => ({
+  x: Math.random() * canvas.width,
+  y: Math.random() * canvas.height,
+  vx: (Math.random() - 0.5) * 2,
+  vy: (Math.random() - 0.5) * 2,
+  r: Math.random() * 3 + 2,
+  color: d3.interpolateRainbow(Math.random())
 }));
 
-const simulation = d3.forceSimulation(nodes)
-  .force('link', d3.forceLink(links).distance(60).strength(0.5))
-  .force('charge', d3.forceManyBody().strength(-30))
-  .force('center', d3.forceCenter(width / 2, height / 2));
-
-const link = svg.append('g')
-  .attr('stroke', 'rgba(255,255,255,0.2)')
-  .selectAll('line')
-  .data(links)
-  .join('line');
-
-const node = svg.append('g')
-  .selectAll('circle')
-  .data(nodes)
-  .join('circle')
-  .attr('r', d => d.r)
-  .attr('fill', () => d3.interpolateRainbow(Math.random()))
-  .call(d3.drag()
-    .on('start', dragstarted)
-    .on('drag', dragged)
-    .on('end', dragended));
-
-simulation.on('tick', () => {
-  link
-    .attr('x1', d => d.source.x)
-    .attr('y1', d => d.source.y)
-    .attr('x2', d => d.target.x)
-    .attr('y2', d => d.target.y);
-  node
-    .attr('cx', d => d.x)
-    .attr('cy', d => d.y);
-});
-
-svg.on('mousemove', event => {
-  const [x, y] = d3.pointer(event);
-  simulation.alphaTarget(0.3).restart();
+d3.timer(() => {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
   nodes.forEach(n => {
-    n.vx += (x - n.x) * 0.001;
-    n.vy += (y - n.y) * 0.001;
+    n.x += n.vx;
+    n.y += n.vy;
+    if (n.x < n.r || n.x > canvas.width - n.r) n.vx *= -1;
+    if (n.y < n.r || n.y > canvas.height - n.r) n.vy *= -1;
+    ctx.beginPath();
+    ctx.arc(n.x, n.y, n.r, 0, 2 * Math.PI);
+    ctx.fillStyle = n.color;
+    ctx.fill();
   });
 });
-
-function dragstarted(event, d) {
-  if (!event.active) simulation.alphaTarget(0.3).restart();
-  d.fx = d.x;
-  d.fy = d.y;
-}
-function dragged(event, d) {
-  d.fx = event.x;
-  d.fy = event.y;
-}
-function dragended(event, d) {
-  if (!event.active) simulation.alphaTarget(0);
-  d.fx = null;
-  d.fy = null;
-}
 
 function login(user) {
   localStorage.setItem('user', user);

--- a/public/style.css
+++ b/public/style.css
@@ -18,7 +18,7 @@ h1, h2, h3, h4, h5, h6 {
   height: 100vh;
   color: #fff;
   text-align: center;
-  background: linear-gradient(135deg, #1e3c72, #2a5298);
+  background: transparent;
 }
 #landing h1 {
   font-size: 16px;


### PR DESCRIPTION
## Summary
- Replace hidden SVG background with a full-screen canvas element
- Add D3-driven animation of 100 colorful nodes bouncing across the page
- Make landing container transparent so the animated background shows through

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae68d19e9c832b9ac5b4f5425477a3