### PR TITLE
Add GPT-5 option and improve Codex page

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -31,6 +31,7 @@
           <option value="gpt-4o-mini">gpt-4o-mini</option>
           <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
           <option value="gpt-4">gpt-4</option>
+          <option value="gpt-5">gpt-5</option>
         </select>
         <span id="balance" class="ml-2 text-yellow-400"></span>
       </header>

--- a/public/codex.html
+++ b/public/codex.html
@@ -4,23 +4,42 @@
   <meta charset="UTF-8">
   <title>Carlton Codex</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/github-dark.min.css">
 </head>
-<body>
-  <section id="codex-page">
-    <h2>Codex</h2>
-    <div id="github-connect">
-      <input type="text" id="repo-url" placeholder="owner/repo">
-      <input type="password" id="github-token" placeholder="GitHub token (optional)">
-      <button id="load-repo">Load Repo</button>
-      <select id="file-select"></select>
-    </div>
-    <textarea id="codex-input" placeholder="Enter code prompt"></textarea>
-    <button id="codex-submit">Run</button>
-    <pre><code id="codex-output"></code></pre>
-  </section>
+<body class="bg-gray-900 text-white">
+  <div id="codex-app" class="max-w-4xl mx-auto p-4 space-y-4">
+    <header class="flex items-center gap-2 mb-4">
+      <img src="carlton-logo.svg" alt="Carlton logo" class="w-10 h-10">
+      <h1 class="text-xl font-bold">Carlton Codex</h1>
+    </header>
+
+    <section id="codex-page" class="space-y-4">
+      <div id="codex-instructions" class="text-sm text-gray-300 space-y-2">
+        <p>Connect to a GitHub repository and run code prompts against any file.</p>
+        <ul class="list-disc pl-5 space-y-1">
+          <li>Enter the repository in the form <code class="bg-gray-800 px-1 rounded">owner/repo</code>.</li>
+          <li>Optionally <a href="https://github.com/settings/tokens" target="_blank" class="text-blue-400 underline">create a GitHub access token</a> for private repositories.</li>
+          <li>See the <a href="https://docs.github.com/en/rest" target="_blank" class="text-blue-400 underline">GitHub REST API docs</a> for more help.</li>
+        </ul>
+      </div>
+
+      <div id="github-connect" class="flex flex-col sm:flex-row gap-2">
+        <input type="text" id="repo-url" placeholder="owner/repo" class="flex-1 p-2 bg-gray-800 rounded">
+        <input type="password" id="github-token" placeholder="GitHub token (optional)" class="flex-1 p-2 bg-gray-800 rounded">
+        <button id="load-repo" class="p-2 bg-green-600 rounded">Load Repo</button>
+        <select id="file-select" class="flex-1 p-2 bg-gray-800 rounded"></select>
+      </div>
+
+      <textarea id="codex-input" placeholder="Enter code prompt" class="w-full h-40 p-2 bg-gray-800 rounded"></textarea>
+      <button id="codex-submit" class="p-2 bg-blue-600 rounded w-full sm:w-auto">Run</button>
+      <pre class="bg-gray-800 p-4 rounded overflow-auto"><code id="codex-output"></code></pre>
+    </section>
+  </div>
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
   <script src="codex.js"></script>
 </body>
 </html>
+

--- a/public/start.js
+++ b/public/start.js
@@ -8,7 +8,7 @@ function resize() {
 resize();
 window.addEventListener('resize', resize);
 
-const nodes = d3.range(100).map(() => ({
+const nodes = d3.range(500).map(() => ({
   x: Math.random() * canvas.width,
   y: Math.random() * canvas.height,
   vx: (Math.random() - 0.5) * 2,


### PR DESCRIPTION
## Summary
- add GPT-5 to chat model selector
- show more animated nodes on landing page
- redesign Codex page with setup instructions and helper links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6ba34818832b90c74b3ed51b8a8b