### PR TITLE
feat: allow custom rss feeds

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -56,6 +56,11 @@
       <h3 class="mb-2 text-base">Settings</h3>
       <form id="settings-form" class="flex flex-col gap-2">
         <div id="rss-options" class="flex flex-col gap-2"></div>
+        <div id="custom-feed" class="flex flex-col gap-2">
+          <input type="text" id="custom-feed-name" class="p-1 bg-gray-700 text-white rounded" placeholder="Feed Name">
+          <input type="text" id="custom-feed-url" class="p-1 bg-gray-700 text-white rounded" placeholder="Feed URL">
+          <button type="button" id="add-feed-btn" class="p-2 bg-blue-600 text-white rounded"><i class="fas fa-plus"></i> Add Feed</button>
+        </div>
         <label class="flex items-center gap-2">Zip Code
           <input type="text" id="zip-input" class="p-1 bg-gray-700 text-white rounded w-24" placeholder="e.g. 10001">
         </label>

--- a/public/chat.js
+++ b/public/chat.js
@@ -16,6 +16,9 @@ const rssMarquee = document.getElementById('rss-marquee');
 const zipInput = document.getElementById('zip-input');
 const weatherDiv = document.getElementById('weather');
 const tickerLabel = document.querySelector('.ticker-label');
+const customFeedName = document.getElementById('custom-feed-name');
+const customFeedUrl = document.getElementById('custom-feed-url');
+const addFeedBtn = document.getElementById('add-feed-btn');
 
 function updateTickerLabel() {
   if (window.matchMedia('(max-width: 600px)').matches) {
@@ -31,13 +34,14 @@ function getFlyInClass() {
   const dirs = ['fly-in-left', 'fly-in-right', 'fly-in-top', 'fly-in-bottom'];
   return dirs[Math.floor(Math.random() * dirs.length)];
 }
-
-const allFeeds = {
+const defaultFeeds = {
   cnn: { name: 'CNN', url: 'https://rss.cnn.com/rss/cnn_topstories.rss' },
   abc: { name: 'ABC', url: 'https://feeds.abcnews.com/abcnews/topstories' },
   sports: { name: 'Sports', url: 'https://www.espn.com/espn/rss/news' }
 };
-let selectedFeeds = JSON.parse(localStorage.getItem('rssFeeds') || '["cnn","abc","sports"]');
+let customFeeds = JSON.parse(localStorage.getItem('customFeeds') || '{}');
+const allFeeds = { ...defaultFeeds, ...customFeeds };
+let selectedFeeds = JSON.parse(localStorage.getItem('rssFeeds') || JSON.stringify(Object.keys(defaultFeeds)));
 let userZip = localStorage.getItem('zip') || '';
 const studyData = [];
 
@@ -106,6 +110,21 @@ settingsBtn.addEventListener('click', () => {
   renderSettings();
   settingsModal.classList.remove('hidden');
   settingsModal.classList.add('flex');
+});
+
+addFeedBtn.addEventListener('click', () => {
+  const name = customFeedName.value.trim();
+  const url = customFeedUrl.value.trim();
+  if (!name || !url) return;
+  const key = `custom_${Date.now()}`;
+  allFeeds[key] = { name, url };
+  customFeeds[key] = { name, url };
+  localStorage.setItem('customFeeds', JSON.stringify(customFeeds));
+  selectedFeeds.push(key);
+  localStorage.setItem('rssFeeds', JSON.stringify(selectedFeeds));
+  renderSettings();
+  customFeedName.value = '';
+  customFeedUrl.value = '';
 });
 
 settingsForm.addEventListener('submit', e => {


### PR DESCRIPTION
## Summary
- add inputs in settings modal to capture custom RSS feed name and URL
- store custom feeds in localStorage and merge with default feeds
- update settings logic to add new feeds and include them in marquee

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6edab5d8832b89e2e2668183e737