### PR TITLE
Make ticker links clickable

### DIFF
--- a/public/chat.js
+++ b/public/chat.js
@@ -300,20 +300,22 @@ function renderSettings() {
 }
 
 async function updateMarquee() {
-  const titles = [];
+  const items = [];
   for (const key of selectedFeeds) {
     const url = allFeeds[key].url;
     try {
       const res = await fetch(`/api/rss?url=${encodeURIComponent(url)}`);
       const json = await res.json();
-      titles.push(...json.titles);
+      if (json.items) items.push(...json.items);
     } catch (err) {
       console.error(err);
     }
   }
   const content = document.createElement('div');
   content.className = 'marquee-content';
-  content.innerHTML = titles.map(t => `<span>${t}</span>`).join('');
+  content.innerHTML = items
+    .map(({ title, link }) => `<span><a href="${link}" target="_blank" rel="noopener">${title}</a></span>`) 
+    .join('');
   rssMarquee.innerHTML = '';
   rssMarquee.appendChild(content);
 }

--- a/public/style.css
+++ b/public/style.css
@@ -356,6 +356,13 @@ pre{
   color: red;
   margin-right: 0.5rem;
 }
+#rss-ticker a {
+  color: inherit;
+  text-decoration: none;
+}
+#rss-ticker a:hover {
+  text-decoration: underline;
+}
 @keyframes marquee {
   0% { transform: translateX(0); }
   100% { transform: translateX(-100%); }

--- a/server.js
+++ b/server.js
@@ -130,8 +130,8 @@ app.get('/api/rss', async (req, res) => {
   if (!url) return res.status(400).json({ error: 'url required' });
   try {
     const feed = await parser.parseURL(url);
-    const titles = feed.items.map(i => i.title);
-    res.json({ titles });
+    const items = feed.items.map(i => ({ title: i.title, link: i.link }));
+    res.json({ items });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- Return RSS item links from the API
- Render news ticker items as links opening in a new tab
- Style ticker links to inherit colors and underline on hover

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae6fda2d8c832bbb237059e777d11a