### PR TITLE
feat: add Amazon Native Shopping Ads banner

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -22,6 +22,22 @@
       </section>
     </aside>
     <main id="chat">
+      <div id="amazon-ad-banner" class="w-full flex justify-center mb-2">
+        <!-- Amazon Associates Native Shopping Ads placeholder -->
+        <script type="text/javascript">
+          amzn_assoc_ad_type = "responsive_search_widget";
+          amzn_assoc_tracking_id = "YOUR_APP_ID";
+          amzn_assoc_marketplace = "amazon";
+          amzn_assoc_region = "US";
+          amzn_assoc_default_search_phrase = "tech gadgets";
+          amzn_assoc_default_category = "All";
+          amzn_assoc_linkid = "YOUR_APP_KEY";
+          amzn_assoc_placement = "adunit0";
+          amzn_assoc_search_bar = "true";
+          amzn_assoc_title = "Shop Related Products";
+        </script>
+        <script src="//z-na.amazon-adsystem.com/widgets/onejs?MarketPlace=US"></script>
+      </div>
       <header class="flex items-center p-2 bg-gray-900 border-b border-gray-700 text-base">
         <button id="settings-btn" class="p-2 bg-gray-800 text-white rounded mr-2"><i class="fas fa-cog"></i></button>
         <img src="carlton-logo.svg" id="logo" alt="Carlton logo" class="w-10 h-10">


### PR DESCRIPTION
## Summary
- embed Amazon Associates Native Shopping Ads script at top of chat page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae71988188832bb4c2ab707b5a144b