### PR TITLE
Simplify start screen login

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,10 +14,10 @@
   <div id="landing">
      <img src="opp.png" id="logo2" alt="Carlton logo" class="w-10 h-10">
     <div id="login">
-      <input type="text" id="username" placeholder="Username">
-      <input type="password" id="password" placeholder="Password">
+      <input type="text" id="heyInput" placeholder="Type 'Hey'">
       <button id="loginbtn">Login</button>
       <button id="guestbtn">Guest Login</button>
+      <p id="instructions">Type "Hey" and click Login to continue.</p>
     </div>
   </div>
   <script src="start.js"></script>

--- a/public/start.js
+++ b/public/start.js
@@ -65,7 +65,7 @@ canvas.addEventListener('click', e => {
 });
 
 document.addEventListener('keypress', e => {
-  if (e.key && e.key.length === 1) {
+  if (e.target.tagName !== 'INPUT' && e.key && e.key.length === 1) {
     formLetter(e.key);
   }
 });
@@ -98,14 +98,13 @@ function login(user) {
 }
 
 document.getElementById('loginbtn').addEventListener('click', () => {
-  const u = document.getElementById('username').value;
-  const p = document.getElementById('password').value;
-  if (u === 'admin' && p === 'admin123') {
-    login('admin');
+  const val = document.getElementById('heyInput').value.trim().toLowerCase();
+  if (val === 'hey') {
+    login('user');
   } else {
     Swal.fire({
       icon: 'error',
-      title: 'Invalid credentials',
+      title: 'Please type "Hey"',
       background: '#1f2937',
       color: '#fff'
     });


### PR DESCRIPTION
## Summary
- Replace username/password with a single field requiring users to type "Hey" before logging in
- Show instructions and preserve guest login option
- Ignore keypresses from the input so background dots keep moving

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef57f0a7c832bac9354099ab8dfb5